### PR TITLE
consistently use positive/negative values for power

### DIFF
--- a/simulator/power_meter.py
+++ b/simulator/power_meter.py
@@ -76,9 +76,10 @@ class HttpPowerMeter(PowerMeter):
 
 class MockPowerMeter(PowerMeter):
 
-    def __init__(self, return_value: float, name: Optional[str] = None):
+    def __init__(self, p: float, name: Optional[str] = None):
         super().__init__(name)
-        self.return_value = return_value
+        assert p <= 0
+        self.p = p
 
     def measure(self) -> float:
-        return self.return_value
+        return self.p

--- a/vessim/computing_system.py
+++ b/vessim/computing_system.py
@@ -12,7 +12,7 @@ class ComputingSystemSim(VessimSimulator):
             "ComputingSystem": {
                 "public": True,
                 "params": ["power_meters", "pue"],
-                "attrs": ["p_cons"],
+                "attrs": ["p"],
             },
         },
     }
@@ -39,14 +39,14 @@ class ComputingSystemModel(VessimModel):
         power_meters: A list of PowerMeter objects
             representing power meters in the system.
         pue: The power usage effectiveness of the system.
-        p_cons: The power consumption of the system, computed in the step
-            method.
+        p: The power consumption of the system, computed in the step method.
+            Is always <= 0.
     """
 
     def __init__(self, power_meters: List[PowerMeter], pue: float):
         self.power_meters = power_meters
         self.pue = pue
-        self.p_cons = 0.0
+        self.p = 0.0
 
     def step(self, time: int, inputs: dict) -> None:
         """Updates the power consumption of the system.
@@ -54,4 +54,4 @@ class ComputingSystemModel(VessimModel):
         The power consumption is calculated as the product of the PUE and the
         sum of the node power of all power meters.
         """
-        self.p_cons = self.pue * sum(pm.measure() for pm in self.power_meters)
+        self.p = self.pue * sum(pm.measure() for pm in self.power_meters)

--- a/vessim/microgrid.py
+++ b/vessim/microgrid.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Callable
+from typing import Optional, Callable, Union
 
 from vessim.core import VessimSimulator, VessimModel
 from vessim.storage import Storage, StoragePolicy, DefaultStoragePolicy
@@ -13,7 +13,7 @@ class MicrogridSim(VessimSimulator):
             "Microgrid": {
                 "public": True,
                 "params": ["storage", "policy"],
-                "attrs": ["p_gen", "p_cons", "p_grid"],
+                "attrs": ["p", "p_delta"],
             },
         },
     }
@@ -32,18 +32,15 @@ class MicrogridModel(VessimModel):
                  policy: Optional[StoragePolicy] = None):
         self.storage = storage
         self.policy = policy if policy is not None else DefaultStoragePolicy()
-        self.p_gen = 0.0
-        self.p_cons = 0.0
-        self.p_grid = 0.0
+        self.p_delta = 0.0
         self._last_step_time = 0
 
     def step(self, time: int, inputs: dict) -> None:
-        self.p_gen = inputs["p_gen"]
-        self.p_cons = inputs["p_cons"]
-        p_delta = self.p_gen - self.p_cons
+        p: Union[float, list[float]] = inputs["p"]
+        p_delta = p if type(p) == float else sum(inputs["p"])
         time_since_last_step = time - self._last_step_time
         if self.storage is None:
-            self.p_grid = p_delta
+            self.p_delta = p_delta
         else:
-            self.p_grid = self.policy.apply(self.storage, p_delta, time_since_last_step)
+            self.p_delta = self.policy.apply(self.storage, p_delta, time_since_last_step)
         self._last_step_time = time


### PR DESCRIPTION
Consumption is always denoted with negative values, production with positive values. This makes it easy to e.g. sum up the power delta in the microgrid