### PR TITLE
Compatibility adjustements: python 3.8.0

### DIFF
--- a/.github/workflows/vessim-ci.yml
+++ b/.github/workflows/vessim-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.8.0'
     
     # get rid of DeprecationWarning related to Jupyter paths when running pytest
     - name: Set JUPYTER_PLATFORM_DIRS environment variable

--- a/.github/workflows/vessim-ci.yml
+++ b/.github/workflows/vessim-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8.0'
+        python-version: '3.8.17'
     
     # get rid of DeprecationWarning related to Jupyter paths when running pytest
     - name: Set JUPYTER_PLATFORM_DIRS environment variable

--- a/examples/scenario_1.py
+++ b/examples/scenario_1.py
@@ -8,7 +8,7 @@ applications'. Documentation for this is in progress.
 """
 import argparse
 from datetime import timedelta
-from typing import Union
+from typing import List, Union
 
 import mosaik # type: ignore
 import pandas as pd
@@ -77,8 +77,8 @@ def run_simulation(sim_start: str,
                    duration: int,
                    carbon_data_file: str,
                    solar_data_file: str,
-                   nodes: list[Node],
-                   power_meters: list[PowerMeter],
+                   nodes: List[Node],
+                   power_meters: List[PowerMeter],
                    battery: SimpleBattery,
                    policy: StoragePolicy):
     """Execute the example scenario simulation."""

--- a/examples/scenario_1.py
+++ b/examples/scenario_1.py
@@ -77,7 +77,7 @@ def run_simulation(sim_start: str,
                    duration: int,
                    carbon_data_file: str,
                    solar_data_file: str,
-                   nodes: list[Node],
+                   nodes: List[Node],
                    power_meters: List[PowerMeter],
                    battery: SimpleBattery,
                    policy: StoragePolicy):

--- a/examples/scenario_1.py
+++ b/examples/scenario_1.py
@@ -77,7 +77,7 @@ def run_simulation(sim_start: str,
                    duration: int,
                    carbon_data_file: str,
                    solar_data_file: str,
-                   nodes: List[Node],
+                   nodes: list[Node],
                    power_meters: List[PowerMeter],
                    battery: SimpleBattery,
                    policy: StoragePolicy):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "vessim"
 dynamic = ["version", "description"]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 keywords = ["simulation", "energy system", "testbed", "carbon-aware"]
 authors = [{name = "Philipp Wiesner", email = "wiesner@tu-berlin.de"}]
@@ -15,7 +15,6 @@ classifiers = [
   "Topic :: Software Development :: Testing",
   "Topic :: Education",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -61,7 +60,7 @@ name = "vessim"
 
 [tool.black]
 line-length = 90  # Set the maximum characters per line
-target-version = "py37"   # Set python versions that black should format the code for
+target-version = "py38"   # Set python versions that black should format the code for
 include = '\.py$'  # Format only python files
 
 [tool.ruff]
@@ -87,7 +86,7 @@ fixable = ["D", "E", "W"]
 unfixable = ["F"]
 
 line-length = 90  # Set the maximum characters per line (similar to black)
-target-version = "py37"  # Set python version for linting (similar to black)
+target-version = "py38"  # Set python version for linting (similar to black)
 include = ["*.py"]  # Only enable linting for python files (similar to black)
 
 # Exclude specific directories and all defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ build-backend = "flit_core.buildapi"
 [tool.flit.sdist]
 exclude = ["data"]
 
+[tool.flit.module]
+name = "vessim"
 
 [tool.black]
 line-length = 90  # Set the maximum characters per line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
   "Topic :: Software Development :: Testing",
   "Topic :: Education",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -51,7 +53,7 @@ exclude = ["data"]
 
 [tool.black]
 line-length = 90  # Set the maximum characters per line
-target-version = ['py311']  # Set python version that black should format the code for
+target-version = ['py37', 'py38', 'py311']   # Set python versions that black should format the code for
 include = '\.py$'  # Format only python files
 
 
@@ -73,7 +75,7 @@ fixable = ["D", "E", "W"]
 unfixable = ["F"]
 
 line-length = 90  # Set the maximum characters per line (similar to black)
-target-version = "py311"  # Set python version for linting (similar to black)
+target-version = ['py37', 'py38', 'py311']  # Set python version for linting (similar to black)
 include = ["*.py"]  # Only enable linting for python files (similar to black)
 
 # Exclude specific directories and all defaults
@@ -83,6 +85,6 @@ extend-exclude = ["example_node", "simulator/power_meter.py", "carbon-aware_cont
 [tool.ruff.pydocstyle]
 convention = "google"
 
-
+# Configure mypy to ignore missing imports
 [mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ exclude = ["data"]
 
 [tool.black]
 line-length = 90  # Set the maximum characters per line
-target-version = ['py37', 'py38', 'py311']   # Set python versions that black should format the code for
+target-version = ['py37']   # Set python versions that black should format the code for
 include = '\.py$'  # Format only python files
 
 
@@ -75,7 +75,7 @@ fixable = ["D", "E", "W"]
 unfixable = ["F"]
 
 line-length = 90  # Set the maximum characters per line (similar to black)
-target-version = ['py37', 'py38', 'py311']  # Set python version for linting (similar to black)
+target-version = ['py37']  # Set python version for linting (similar to black)
 include = ["*.py"]  # Only enable linting for python files (similar to black)
 
 # Exclude specific directories and all defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ exclude = ["data"]
 
 [tool.black]
 line-length = 90  # Set the maximum characters per line
-target-version = ['py37']   # Set python versions that black should format the code for
+target-version = "py37"   # Set python versions that black should format the code for
 include = '\.py$'  # Format only python files
 
 
@@ -75,7 +75,7 @@ fixable = ["D", "E", "W"]
 unfixable = ["F"]
 
 line-length = 90  # Set the maximum characters per line (similar to black)
-target-version = ['py37']  # Set python version for linting (similar to black)
+target-version = "py37"  # Set python version for linting (similar to black)
 include = ["*.py"]  # Only enable linting for python files (similar to black)
 
 # Exclude specific directories and all defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ dependencies = [
 requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.module]
-name = "vessim"
-
 [tool.flit.sdist]
 exclude = ["data"]
 
@@ -66,7 +63,6 @@ name = "vessim"
 line-length = 90  # Set the maximum characters per line
 target-version = "py37"   # Set python versions that black should format the code for
 include = '\.py$'  # Format only python files
-
 
 [tool.ruff]
 # Enable Ruff to check for issues (https://beta.ruff.rs/docs/rules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ name = "vessim"
 
 [tool.black]
 line-length = 90  # Set the maximum characters per line
-target-version = "py38"   # Set python versions that black should format the code for
+target-version = ['py38']   # Set python versions that black should format the code for
 include = '\.py$'  # Format only python files
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,20 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = [ # Optional
+dependencies = [
   "pandas",
   "mosaik",
   "mosaik-api",
+  "requests",
+  "fastapi",
+  "docker",
+  "redis",
+  "uvicorn",
 ]
 
-# [project.optional-dependencies] # Optional
-# dev = ["check-manifest"]
+#[project.optional-dependencies]
+#sil = [
+#]
 # test = ["coverage"]
 
 [project.urls]  # Optional
@@ -47,6 +53,9 @@ dependencies = [ # Optional
 requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.flit.module]
+name = "vessim"
+
 [tool.flit.sdist]
 exclude = ["data"]
 
@@ -60,8 +69,14 @@ include = '\.py$'  # Format only python files
 
 
 [tool.ruff]
-# Enable Ruff to check for docstring-related (D), pycodestyle-related (E, W), and Pyflakes-related (F) issues
-select = ["D", "E", "F", "W"]
+# Enable Ruff to check for issues (https://beta.ruff.rs/docs/rules)
+select = [
+  "E", "W",  # pycodestyle (error and warning)
+  "D",  # docstrings
+  "F",  # Pyflakes
+  "N",  # variable naming
+  #  "B",  # flake8-bugbear
+]
 
 # For now the following rules are disabled:
 #   D100: Missing docstring in public module
@@ -69,8 +84,7 @@ select = ["D", "E", "F", "W"]
 #   D102: Missing docstring in public method
 #   D103: Missing docstring in public function
 #   D107: Missing docstring in __init__
-#   F401: Imported but unused
-ignore = ["D100", "D101", "D102", "D103", "D107", "F401"]
+ignore = ["D100", "D101", "D102", "D103", "D107"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["D", "E", "W"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 
 # analysis
 jupyterlab
-matplotlib==3.6
+matplotlib # ==3.6 is not compatible with python 3.7.0 instead 3.5.3 is installed
 seaborn==0.12.2
 
 # database

--- a/vessim/cosim/_util.py
+++ b/vessim/cosim/_util.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Type, Dict, Any, Union
+from typing import List, Type, Dict, Any, Union
 
 import mosaik_api # type: ignore
 import pandas as pd
@@ -102,8 +102,8 @@ class VessimSimulator(mosaik_api.Simulator, ABC):
 
 
 def _convert_inputs(
-    attrs: dict[str, dict[str, Any]]
-) -> dict[str, Union[Any, list[Any]]]:
+    attrs: Dict[str, Dict[str, Any]]
+) -> Dict[str, Union[Any, List[Any]]]:
     """Converts Mosaik step inputs into a simpler format suitable for Vessim.
 
     If there is a single input, only the input is being returned.

--- a/vessim/cosim/energy_system_interface.py
+++ b/vessim/cosim/energy_system_interface.py
@@ -60,7 +60,7 @@ class _EnergySystemInterfaceModel(VessimModel):
 
     def __init__(
         self,
-        nodes: list[Node],
+        nodes: List[Node],
         battery: SimpleBattery,
         policy: DefaultStoragePolicy,
         db_host: str = "127.0.0.1",

--- a/vessim/cosim/energy_system_interface.py
+++ b/vessim/cosim/energy_system_interface.py
@@ -228,7 +228,7 @@ class _EnergySystemInterfaceModel(VessimModel):
                     status_code=400,
                     detail=f"{power_mode} is not a valid power mode. "
                            f"Available power modes: {power_modes}"
-            )
+                )
             self.redis_docker.redis.hset("node.power_mode", str(item_id), power_mode)
             return node
 

--- a/vessim/cosim/microgrid.py
+++ b/vessim/cosim/microgrid.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from vessim.core.storage import Storage, StoragePolicy, DefaultStoragePolicy
 from vessim.cosim._util import VessimSimulator, VessimModel
@@ -35,7 +35,7 @@ class _MicrogridModel(VessimModel):  # TODO abstract away
         self._last_step_time = 0
 
     def step(self, time: int, inputs: dict) -> None:
-        p: Union[float, list[float]] = inputs["p"]
+        p: Union[float, List[float]] = inputs["p"]
         p_delta = p if type(p) == float else sum(inputs["p"])
         time_since_last_step = time - self._last_step_time
         if self.storage is None:


### PR DESCRIPTION
In order for the project to be compatible with python 3.8.0, the following changes were made:
- changed all occurences of list and dict to List and Dict: the built-in collection types list and dict were introduced in [https://docs.python.org/3/whatsnew/3.9.html](python 3.9)
- adjusted the pyproject.toml to support python 3.8 
- fixed "missing module vessim" error
-  adjusted ci to be tested with python 3.8.17 (because 3.8.0 does not exist)