### PR TITLE
Disabled Incorrect Mosaik Warnings

### DIFF
--- a/examples/cosim_sil_example.py
+++ b/examples/cosim_sil_example.py
@@ -16,6 +16,7 @@ from vessim.core.microgrid import SimpleMicrogrid
 from vessim.core.simulator import Generator, CarbonApi
 from vessim.sil.node import Node
 from vessim.sil.power_meter import HttpPowerMeter
+from vessim.cosim._util import disable_mosaik_warnings
 
 COSIM_SOL_CONFIG = {
     **COSIM_CONFIG,
@@ -24,6 +25,8 @@ COSIM_SOL_CONFIG = {
     },
 }
 SERVER_ADDRESS = "http://34.159.124.254"
+
+disable_mosaik_warnings(behind_threshold=0.01)
 
 
 def run_simulation():

--- a/vessim/cosim/_util.py
+++ b/vessim/cosim/_util.py
@@ -142,18 +142,14 @@ def disable_mosaik_warnings(behind_threshold: float):
     # Define a function to filter out WARNING level logs
     def filter_record(record):
         #print(record)
-        if (
-            record["level"].name == "WARNING" and
-            record["name"].startswith("mosaik") and
-            (
-                record["function"] == "_check_attributes_values" or
-                record["function"] =="rt_check" and
-                float(record["message"].split(' - ')[1].split('s')[0]) < behind_threshold
-            )
-        ):
-            return False
-        else:
-            return True
+        is_warning = record["level"].name == "WARNING"
+        is_mosaik_log = record["name"].startswith("mosaik")
+        is_below_threshold = (
+            record["function"] == "_check_attributes_values" or
+            record["function"] =="rt_check" and
+            float(record["message"].split(' - ')[1].split('s')[0]) < behind_threshold
+        )
+        return not (is_warning and is_mosaik_log and is_below_threshold)
 
     # Add the filter to the logger
     logger.remove()

--- a/vessim/cosim/_util.py
+++ b/vessim/cosim/_util.py
@@ -1,6 +1,8 @@
+import sys
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from typing import Type, Dict, Any, Union
+from loguru import logger
 
 import mosaik_api  # type: ignore
 import pandas as pd
@@ -122,3 +124,37 @@ def simplify_inputs(attrs: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
     for key, val_dict in attrs.items():
         result[key] = list(val_dict.values())[0]
     return result
+
+
+def disable_mosaik_warnings(behind_threshold: float):
+    """Disables Mosaik's incorrect Loguru warnings.
+
+    Mosaik currently deems specific attribute connections as incorrect and logs
+    them as warnings. Also the simulation is always behind by a few fractions
+    of a second (which is fine, code needs time to execute) which Mosaik also
+    logs as a Warning. These Warnings are flagged as bugs in Mosaik's current
+    developement and should be fixed within its next release. Until then, this
+    function should do.
+
+    Args:
+        behind_threshold: Time the simulation is allowed to be behind schedule.
+    """
+    # Define a function to filter out WARNING level logs
+    def filter_record(record):
+        #print(record)
+        if (
+            record["level"].name == "WARNING" and
+            record["name"].startswith("mosaik") and
+            (
+                record["function"] == "_check_attributes_values" or
+                record["function"] =="rt_check" and
+                float(record["message"].split(' - ')[1].split('s')[0]) < behind_threshold
+            )
+        ):
+            return False
+        else:
+            return True
+
+    # Add the filter to the logger
+    logger.remove()
+    logger.add(sys.stdout, filter=filter_record)

--- a/vessim/cosim/_util.py
+++ b/vessim/cosim/_util.py
@@ -144,13 +144,14 @@ def disable_mosaik_warnings(behind_threshold: float):
         #print(record)
         is_warning = record["level"].name == "WARNING"
         is_mosaik_log = record["name"].startswith("mosaik")
+        is_attribute = record["function"] == "_check_attributes_values"
         is_below_threshold = (
-            record["function"] == "_check_attributes_values" or
-            record["function"] =="rt_check" and
+            record["function"] == "rt_check" and
             float(record["message"].split(' - ')[1].split('s')[0]) < behind_threshold
         )
-        return not (is_warning and is_mosaik_log and is_below_threshold)
+        return not (is_warning and is_mosaik_log and (is_below_threshold or is_attribute))
 
     # Add the filter to the logger
     logger.remove()
     logger.add(sys.stdout, filter=filter_record)
+


### PR DESCRIPTION
Added a function that disables incorrect mosaik warnings. Mosaik currently deems specific attribute connections as incorrect and logs them as warnings. Also the simulation is always behind by a few fractions of a second (which is fine, code needs time to execute) which Mosaik also logs as a Warning. These Warnings are flagged as bugs in Mosaik's current developement and should be fixed within its next release. Until then, this function should do.

Thanks @kilianp14 for pointing out the need for a threshold argument for the simulation time.