### PR TITLE
Disabled Uvicorn Logs

### DIFF
--- a/vessim/sil/api_server.py
+++ b/vessim/sil/api_server.py
@@ -40,7 +40,12 @@ class ApiServer(multiprocessing.Process):
 
     def run(self):
         """Called with `multiprocessing.Process.start()`. Runs the uvicorn server."""
-        config = uvicorn.Config(app=self.app, host=self.host, port=self.port)
+        config = uvicorn.Config(
+            app=self.app, 
+            host=self.host, 
+            port=self.port, 
+            access_log=False
+        )
         server = uvicorn.Server(config=config)
         server.run()
 


### PR DESCRIPTION
Uvicorn is logging every HTTP request through stdout. This makes the sim output unreadable and debugging not very comfortable. Therefore, I suggest to simply mute them.