### PR TITLE
Docker stopping bug

### DIFF
--- a/examples/cosim_sil_example.py
+++ b/examples/cosim_sil_example.py
@@ -28,7 +28,7 @@ COSIM_SIL_CONFIG = {
 }
 RT_FACTOR = 1/60  # 1 wall-clock second ^= 60 sim seconds
 
-GCP_ADDRESS = "http://34.159.232.190"
+GCP_ADDRESS = "http://35.198.148.144"
 RASPI_ADDRESS = "http://192.168.207.71"
 
 disable_mosaik_warnings(behind_threshold=0.01)

--- a/vessim/sil/api_server.py
+++ b/vessim/sil/api_server.py
@@ -1,14 +1,12 @@
 import multiprocessing
-import os
-import signal
 import json
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from time import sleep
 from datetime import datetime
 from typing import Optional, Dict, Type
 
 import uvicorn  # type: ignore
-from fastapi import FastAPI, HTTPException  # type: ignore
+from fastapi import FastAPI, HTTPException# type: ignore
 from pydantic import BaseModel  # type: ignore
 
 from vessim.sil.redis_docker import RedisDocker
@@ -58,20 +56,22 @@ class ApiServer(multiprocessing.Process):
         server.run()
 
 
-class SilApi:
+class SilApi(ABC):
     """Base class for the API running on the ApiServer in different process.
+
+    Initializes a FastApi instance with an endpoint `/shutdown` for executing
+    necessary cleanup tasks of the child process running the API.
 
     Attributes:
         app: The FastApi instance to be runned.
     """
+
     def __init__(self) -> None:
         self.app = FastAPI()
-        # Endpoint for shutdown of process and cleanup
-        @self.app.post("/shutdown")
+
+        @self.app.put("/shutdown")
         async def shutdown_server():
             self.finalize()
-            os.kill(os.getpid(), signal.SIGINT)
-            return {"message": "Shutting down server"}
 
     @abstractmethod
     def finalize(self) -> None:

--- a/vessim/sil/api_server.py
+++ b/vessim/sil/api_server.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional, Dict, Type
 
 import uvicorn  # type: ignore
-from fastapi import FastAPI, HTTPException# type: ignore
+from fastapi import FastAPI, HTTPException  # type: ignore
 from pydantic import BaseModel  # type: ignore
 
 from vessim.sil.redis_docker import RedisDocker
@@ -50,7 +50,7 @@ class ApiServer(multiprocessing.Process):
         self.api_type = api_type
         self.host = host
         self.port = port
-        self.startup_complete = multiprocessing.Value('b', False)
+        self.startup_complete = multiprocessing.Value("b", False)
 
     def wait_for_startup_complete(self):
         """Waiting for completion of startup process.
@@ -71,10 +71,7 @@ class ApiServer(multiprocessing.Process):
             self.startup_complete.value = True
 
         config = uvicorn.Config(
-            app=api.app,
-            host=self.host,
-            port=self.port,
-            access_log=False
+            app=api.app, host=self.host, port=self.port, access_log=False
         )
         server = uvicorn.Server(config=config)
         server.run()
@@ -117,9 +114,7 @@ class VessimApi(SilApi):
             solar = self.redis_docker.redis.get("solar")
             if solar is not None:
                 solar = float(solar)
-            return SolarModel(
-                solar=solar
-            )
+            return SolarModel(solar=solar)
 
         class CiModel(BaseModel):
             ci: Optional[float]
@@ -129,9 +124,7 @@ class VessimApi(SilApi):
             ci = self.redis_docker.redis.get("ci")
             if ci is not None:
                 ci = float(ci)
-            return CiModel(
-                ci=ci
-            )
+            return CiModel(ci=ci)
 
         class BatterySocModel(BaseModel):
             battery_soc: Optional[float]
@@ -141,9 +134,7 @@ class VessimApi(SilApi):
             battery_soc = self.redis_docker.redis.get("battery_soc")
             if battery_soc is not None:
                 battery_soc = float(battery_soc)
-            return BatterySocModel(
-                battery_soc=battery_soc
-            )
+            return BatterySocModel(battery_soc=battery_soc)
 
         # /sim/
 
@@ -155,12 +146,11 @@ class VessimApi(SilApi):
         @app.get("/sim/collect-set", response_model=CollectSetModel)
         async def get_collect_set() -> CollectSetModel:
             model = CollectSetModel(
-                battery_min_soc=
-                    self._deserialize_redis_hash("battery_min_soc_log"),
-                battery_grid_charge=
-                    self._deserialize_redis_hash("battery_grid_charge_log"),
-                nodes_power_mode=
-                    self._deserialize_redis_hash("power_mode_log")
+                battery_min_soc=self._deserialize_redis_hash("battery_min_soc_log"),
+                battery_grid_charge=self._deserialize_redis_hash(
+                    "battery_grid_charge_log"
+                ),
+                nodes_power_mode=self._deserialize_redis_hash("power_mode_log"),
             )
             self._delete_all_keys_in_hash("battery_min_soc_log")
             self._delete_all_keys_in_hash("battery_grid_charge_log")
@@ -194,14 +184,10 @@ class VessimApi(SilApi):
         async def put_battery(battery: BatteryModel) -> BatteryModel:
             timestamp = datetime.now().isoformat()
             self.redis_docker.redis.hset(
-                "battery_min_soc_log",
-                str(timestamp),
-                battery.min_soc
+                "battery_min_soc_log", str(timestamp), battery.min_soc
             )
             self.redis_docker.redis.hset(
-                "battery_grid_charge_log",
-                str(timestamp),
-                battery.grid_charge
+                "battery_grid_charge_log", str(timestamp), battery.grid_charge
             )
             return battery
 
@@ -216,13 +202,11 @@ class VessimApi(SilApi):
                 raise HTTPException(
                     status_code=400,
                     detail=f"{power_mode} is not a valid power mode. "
-                           f"Available power modes: {power_modes}"
-            )
+                    f"Available power modes: {power_modes}",
+                )
             timestamp = datetime.now().isoformat()
             self.redis_docker.redis.hset(
-                "power_mode_log",
-                str(timestamp),
-                json.dumps({item_id: power_mode})
+                "power_mode_log", str(timestamp), json.dumps({item_id: power_mode})
             )
             return node
 

--- a/vessim/sil/http_client.py
+++ b/vessim/sil/http_client.py
@@ -36,12 +36,12 @@ class HttpClient:
     def put(self, route: str, data: Dict[str, Any]) -> None:
         """Sends a PUT request to the server to update data.
 
-        Raises:
-            HTTPError if response code is != 200.
-
         Args:
             route: The path of the endpoint to send the request to.
             data: The data to be updated, in dictionary format.
+
+        Raises:
+            HTTPError if response code is != 200.
         """
         headers = {"Content-type": "application/json"}
         response = requests.put(
@@ -53,3 +53,22 @@ class HttpClient:
         if response.status_code != 200:
             response.raise_for_status()
 
+    def post(self, route: str, data: Dict[str, Any] = {}) -> None:
+        """Sends a POST request to the server.
+
+        Args:
+            route: The path of the endpoint to send the request to.
+            data: The data to be sent in the request body, in dictionary format.
+
+        Raises:
+            HTTPError if response code is != 200.
+        """
+        headers = {"Content-type": "application/json"}
+        response = requests.put(
+            self.server_address + route,
+            data=json.dumps(data),
+            headers=headers,
+            timeout=self.timeout
+        )
+        if response.status_code != 200:
+            response.raise_for_status()

--- a/vessim/sil/http_client.py
+++ b/vessim/sil/http_client.py
@@ -33,32 +33,12 @@ class HttpClient:
         data = response.json() # assuming the response data is in JSON format
         return data
 
-    def put(self, route: str, data: Dict[str, Any]) -> None:
+    def put(self, route: str, data: Dict[str, Any] = {}) -> None:
         """Sends a PUT request to the server to update data.
 
         Args:
             route: The path of the endpoint to send the request to.
             data: The data to be updated, in dictionary format.
-
-        Raises:
-            HTTPError if response code is != 200.
-        """
-        headers = {"Content-type": "application/json"}
-        response = requests.put(
-            self.server_address + route,
-            data=json.dumps(data),
-            headers=headers,
-            timeout=self.timeout
-        )
-        if response.status_code != 200:
-            response.raise_for_status()
-
-    def post(self, route: str, data: Dict[str, Any] = {}) -> None:
-        """Sends a POST request to the server.
-
-        Args:
-            route: The path of the endpoint to send the request to.
-            data: The data to be sent in the request body, in dictionary format.
 
         Raises:
             HTTPError if response code is != 200.

--- a/vessim/sil/http_client.py
+++ b/vessim/sil/http_client.py
@@ -30,7 +30,7 @@ class HttpClient:
         response = requests.get(self.server_address + route, timeout=self.timeout)
         if response.status_code != 200:
             response.raise_for_status()
-        data = response.json() # assuming the response data is in JSON format
+        data = response.json()  # assuming the response data is in JSON format
         return data
 
     def put(self, route: str, data: Dict[str, Any] = {}) -> None:
@@ -48,7 +48,7 @@ class HttpClient:
             self.server_address + route,
             data=json.dumps(data),
             headers=headers,
-            timeout=self.timeout
+            timeout=self.timeout,
         )
         if response.status_code != 200:
             response.raise_for_status()

--- a/vessim/sil/redis_docker.py
+++ b/vessim/sil/redis_docker.py
@@ -1,7 +1,6 @@
 from time import sleep
 import docker # type: ignore
 import redis # type: ignore
-import atexit
 
 
 class RedisDocker:
@@ -23,8 +22,6 @@ class RedisDocker:
         except docker.errors.DockerException:
             raise RuntimeError("Please start Docker before execution.")
         self.redis = self._connect_redis()
-         # Register cleanup function
-        atexit.register(self.__del__)
 
     def _init_docker(self) -> None:
         """Initializes Docker client and starts Docker container with Redis."""

--- a/vessim/sil/sil_interface.py
+++ b/vessim/sil/sil_interface.py
@@ -45,8 +45,7 @@ class SilInterfaceSim(VessimSimulator):
         for model_instance in self.entities.values():
             model_instance.collector_thread.stop() # type: ignore
             model_instance.collector_thread.join() # type: ignore
-            model_instance.api_server.terminate() # type: ignore
-            model_instance.api_server.join() # type: ignore
+            model_instance.http_client.post("/shutdown") # type: ignore
 
     def next_step(self, time):
         return time + self.step_size

--- a/vessim/sil/sil_interface.py
+++ b/vessim/sil/sil_interface.py
@@ -45,7 +45,9 @@ class SilInterfaceSim(VessimSimulator):
         for model_instance in self.entities.values():
             model_instance.collector_thread.stop() # type: ignore
             model_instance.collector_thread.join() # type: ignore
-            model_instance.http_client.post("/shutdown") # type: ignore
+            model_instance.http_client.put("/shutdown") # type: ignore
+            model_instance.api_server.terminate()
+            model_instance.api_server.join()
 
     def next_step(self, time):
         return time + self.step_size


### PR DESCRIPTION
After the simulation ends, the docker container is now stopped accordingly. The VessimApi now has a base class, which initializes an API endpoint `/shutdown`, which is used to perform clean-up functionality.

Closes #121 