### PR TITLE
Fixed import error in examples/sil_example/cacu.py

### DIFF
--- a/examples/sil_example/carbon-aware_control_unit/cacu.py
+++ b/examples/sil_example/carbon-aware_control_unit/cacu.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from vessim.sil.http_client import HttpClient
 from vessim.sil.loop_thread import LoopThread
-from examples.cosim_example.cosim_example import cacu_scenario
+from examples.cosim_example.cacu import cacu_scenario
 
 
 class RemoteBattery:


### PR DESCRIPTION
There was a merge error because in examples/sil_example/cacu.py this was imported: 
```from pure_sim.cosim_example import cacu_scenario```
and ``pure_sim``was changed so the correct import should be:
```from examples.cosim_example.cacu import cacu_scenario```
