### PR TITLE
fixed merge error from sil_example.py

### DIFF
--- a/examples/sil_example/sil_example.py
+++ b/examples/sil_example/sil_example.py
@@ -11,7 +11,12 @@ This is example experimental and documentation is still in progress.
 import mosaik  # type: ignore
 
 from examples._data import load_carbon_data, load_solar_data
-from examples.cosim_example.cosim_example import COSIM_CONFIG, SIM_START, STORAGE, DURATION
+from examples.cosim_example.cosim_example import (
+    COSIM_CONFIG,
+    SIM_START,
+    STORAGE,
+    DURATION
+)
 from vessim.core.consumer import ComputingSystem
 from vessim.core.microgrid import SimpleMicrogrid
 from vessim.core.simulator import Generator, CarbonApi

--- a/examples/sil_example/sil_example.py
+++ b/examples/sil_example/sil_example.py
@@ -11,7 +11,7 @@ This is example experimental and documentation is still in progress.
 import mosaik  # type: ignore
 
 from examples._data import load_carbon_data, load_solar_data
-from examples.pure_sim.cosim_example import COSIM_CONFIG, SIM_START, STORAGE, DURATION
+from examples.cosim_example.cosim_example import COSIM_CONFIG, SIM_START, STORAGE, DURATION
 from vessim.core.consumer import ComputingSystem
 from vessim.core.microgrid import SimpleMicrogrid
 from vessim.core.simulator import Generator, CarbonApi


### PR DESCRIPTION
There was another wrong pure_sim reference in examples/sil_example/sil_example.py, which led to an unsuccessful run.
I changed ``from examples.pure_sim.cosim_example`` to ``from examples.cosim_example.cosim_example``