### PR TITLE
Changed > to >= for Starting Index

### DIFF
--- a/vessim/__init__.py
+++ b/vessim/__init__.py
@@ -232,7 +232,7 @@ class TimeSeriesApi:
                 .iloc[1:]
             )
 
-        return forecast.loc[(forecast.index > start_time) & (forecast.index <= end_time)]
+        return forecast.loc[(forecast.index >= start_time) & (forecast.index <= end_time)]
 
     def next_update(self, dt: DatetimeLike) -> datetime:
         """Returns the next time of when the trace will change.


### PR DESCRIPTION
When I want a forecast from time point x to y, I'd like for x to also show up in the forecast and not the next value after x, right?