### PR TITLE
Added a PyPi release pipeline

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.8'
     
     - name: Install poetry
       uses: snok/install-poetry@v1

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,7 +1,9 @@
 name: Publish new release on PyPI
 
 # workflow is triggered when a new release is created or a new git tag is pushed to this repository
+# and it can be manually triggered
 on:
+  workflow_dispatch:
   release:
     types: [created]
   push:

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -31,7 +31,7 @@ jobs:
       run: poetry self add poetry-plugin-export
 
     - name: Install dependencies
-      run: poetry install --extras "dev"
+      run: poetry install
 
     - name: Build package out of local poject
       run: poetry build

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,0 +1,43 @@
+name: Publish new release on PyPI
+
+# workflow is triggered when a new release is created or a new git tag is pushed to this repository
+on:
+  release:
+    types: [created]
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    # downloads the repository code to the runner's file system for workflow access
+    - uses: actions/checkout@v2
+    - name: Fetch all history for all tags and branches
+      run: git fetch --prune --unshallow
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+    
+    - name: Install poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: false
+
+    - name: Install poetry dynamic version plugin, extracts version number from git tag
+      run: poetry self add poetry-plugin-export
+
+    - name: Install dependencies
+      run: poetry install --extras "dev"
+
+    - name: Build package out of local poject
+      run: poetry build
+    
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Added a new workflow which is triggered on a new `git tag` , `release` and manually. 
It builds a package with `poetry ` and publishes it on PyPi using credentials. 
As the continuous integration workflows are already implemented, here is the missing continuous delivery :)