### PR TITLE
Fixed dynamic versioning issue

### DIFF
--- a/.github/workflows/building-and-installation.yml
+++ b/.github/workflows/building-and-installation.yml
@@ -30,11 +30,6 @@ jobs:
       with:
         virtualenvs-create: false
 
-    - name: Install poetry dynamic version plugin, extracts version number from git tag
-      run: |
-        pip install poetry-version-plugin
-        poetry self add poetry-version-plugin
-
     - name: Build package out of local poject
       run: poetry build
 

--- a/.github/workflows/building-and-installation.yml
+++ b/.github/workflows/building-and-installation.yml
@@ -31,7 +31,9 @@ jobs:
         virtualenvs-create: false
 
     - name: Install poetry dynamic version plugin, extracts version number from git tag
-      run: poetry self add poetry-plugin-export
+      run: |
+        pip install poetry-version-plugin
+        poetry self add poetry-version-plugin
 
     - name: Build package out of local poject
       run: poetry build

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -28,9 +28,11 @@ jobs:
       uses: snok/install-poetry@v1
       with:
         virtualenvs-create: false
-
+        
     - name: Install poetry dynamic version plugin, extracts version number from git tag
-      run: poetry self add poetry-plugin-export
+      run: |
+        pip install poetry-version-plugin
+        poetry self add poetry-version-plugin
 
     - name: Install dependencies
       run: poetry install


### PR DESCRIPTION
Currently, the dynamic version extraction from git tags does not work because I used wrong commands. 
I tested the workflow on a private repository. After publishing the git tag, poetry uses the correct version number:
![Screenshot 2023-12-12 142003](https://github.com/dos-group/vessim/assets/60232361/0b977a20-a0d8-4767-993b-a8fa2046d5a3)

It should now work as expected :)