### PR TITLE
Moved grid_signals from environment to controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Vessim is a versatile **co-simulation testbed for carbon-aware applications and systems** which connects domain-specific simulators for renewable power generation and energy storage with real software and hardware.
 
-## What can I do with it?
+## Simulated energy systems for computing systems
 
 Vessim allows you to simulate energy systems next to real or simulated computing systems:
 
@@ -20,7 +20,6 @@ from vessim.signal import HistoricalSignal
 from vessim.storage import SimpleBattery
 
 environment = Environment(sim_start="15-06-2022")
-environment.add_grid_signal("carbon_intensity", HistoricalSignal.from_dataset("carbon_data1"))
 
 monitor = Monitor()
 microgrid = Microgrid(
@@ -30,7 +29,6 @@ microgrid = Microgrid(
     ],
     controllers=[monitor],
     storage=SimpleBattery(capacity=100),
-    zone="DE",
     step_size=60,
 )
 environment.add_microgrid(microgrid)
@@ -85,34 +83,32 @@ We are currently working on the following aspects and features:
 
 If you use Vessim in your research, please cite our vision paper:
 
-- Philipp Wiesner, Ilja Behnke and Odej Kao. "[A Testbed for Carbon-Aware Applications and Systems](https://arxiv.org/pdf/2306.09774.pdf)" arXiv:2302.08681 [cs.DC]. 2023.
-<details>
-    <summary>Bibtex</summary>
-    
-    @misc{wiesner2023vessim,
-        title={A Testbed for Carbon-Aware Applications and Systems}, 
-        author={Wiesner, Philipp and Behnke, Ilja and Kao, Odej},
-        year={2023},
-        eprint={2306.09774},
-        archivePrefix={arXiv},
-        primaryClass={cs.DC}
-    }
-</details>
+Philipp Wiesner, Ilja Behnke and Odej Kao. "[A Testbed for Carbon-Aware Applications and Systems](https://arxiv.org/pdf/2306.09774.pdf)" arXiv:2302.08681 [cs.DC]. 2023.
+
+```
+@misc{wiesner2023vessim,
+    title={A Testbed for Carbon-Aware Applications and Systems}, 
+    author={Wiesner, Philipp and Behnke, Ilja and Kao, Odej},
+    year={2023},
+    eprint={2306.09774},
+    archivePrefix={arXiv},
+    primaryClass={cs.DC}
+}
+```
 
 Or our journal paper on software-in-the-loop similation for carbon-aware applications:
-- Philipp Wiesner, Marvin Steinke, Henrik Nickel, Yazan Kitana, and Odej Kao. "[Software-in-the-Loop Simulation for Developing and Testing Carbon-Aware Applications](https://doi.org/10.1002/spe.3275)" Software: Practice and Experience, 53 (12). 2023.
-<details>
-    <summary>Bibtex</summary>
-    
-    @article{wiesner2023sil,
-        author = {Wiesner, Philipp and Steinke, Marvin and Nickel, Henrik and Kitana, Yazan and Kao, Odej},
-        title = {Software-in-the-loop simulation for developing and testing carbon-aware applications},
-        journal = {Software: Practice and Experience},
-        year = {2023},
-        volume = {53},
-        number = {12},
-        pages = {2362-2376},
-        doi = {https://doi.org/10.1002/spe.3275}
-    }
-    
-</details>
+
+Philipp Wiesner, Marvin Steinke, Henrik Nickel, Yazan Kitana, and Odej Kao. "[Software-in-the-Loop Simulation for Developing and Testing Carbon-Aware Applications](https://doi.org/10.1002/spe.3275)" Software: Practice and Experience, 53 (12). 2023.
+
+```
+@article{wiesner2023sil,
+    author = {Wiesner, Philipp and Steinke, Marvin and Nickel, Henrik and Kitana, Yazan and Kao, Odej},
+    title = {Software-in-the-loop simulation for developing and testing carbon-aware applications},
+    journal = {Software: Practice and Experience},
+    year = {2023},
+    volume = {53},
+    number = {12},
+    pages = {2362-2376},
+    doi = {https://doi.org/10.1002/spe.3275}
+}
+```

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -12,16 +12,18 @@ DURATION = 3600 * 24 * 2  # two days
 
 def main(result_csv: str):
     environment = Environment(sim_start=SIM_START)
-    environment.add_grid_signal("carbon_intensity", HistoricalSignal(load_carbon_data()))
 
-    monitor = Monitor()  # stores simulation result on each step
+    ci_signal = HistoricalSignal(load_carbon_data())
+    solar_signal = HistoricalSignal(load_solar_data(sqm=0.4 * 0.5))
+
+    monitor = Monitor(grid_signals={"carbon_intensity": ci_signal})  # stores simulation result on each step
     microgrid = Microgrid(
         actors=[
             ComputingSystem(power_meters=[
                 MockPowerMeter(p=2.194),
                 MockPowerMeter(p=7.6)
             ]),
-            Generator(signal=HistoricalSignal(load_solar_data(sqm=0.4 * 0.5))),
+            Generator(signal=solar_signal),
         ],
         controllers=[monitor],
         storage=SimpleBattery(capacity=100),

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -12,18 +12,14 @@ DURATION = 3600 * 24 * 2  # two days
 
 def main(result_csv: str):
     environment = Environment(sim_start=SIM_START)
-
-    ci_signal = HistoricalSignal(load_carbon_data())
-    solar_signal = HistoricalSignal(load_solar_data(sqm=0.4 * 0.5))
-
-    monitor = Monitor(grid_signals={"carbon_intensity": ci_signal})  # stores simulation result on each step
+    monitor = Monitor()  # stores simulation result on each step
     microgrid = Microgrid(
         actors=[
             ComputingSystem(power_meters=[
                 MockPowerMeter(p=2.194),
                 MockPowerMeter(p=7.6)
             ]),
-            Generator(signal=solar_signal),
+            Generator(signal=HistoricalSignal(load_solar_data(sqm=0.4 * 0.5))),
         ],
         controllers=[monitor],
         storage=SimpleBattery(capacity=100),

--- a/examples/controller_example.py
+++ b/examples/controller_example.py
@@ -23,19 +23,20 @@ def main(result_csv: str):
     environment = Environment(sim_start=SIM_START)
 
     ci_signal = HistoricalSignal(load_carbon_data())
-    
+    monitor = Monitor(grid_signals={"carbon_intensity": ci_signal})  # stores simulation result on each step
+
+    battery = SimpleBattery(capacity=100)
     power_meters = [
         MockPowerMeter(name="mpm0", p=2.194),
         MockPowerMeter(name="mpm1", p=7.6),
     ]
-    battery = SimpleBattery(capacity=100)
-    monitor = Monitor(grid_signals={"carbon_intensity": ci_signal})  # stores simulation result on each step
     carbon_aware_controller = CarbonAwareController(
         power_meters=power_meters,
         battery=battery,
         policy=POLICY,
         carbon_signal=ci_signal,
     )
+
     microgrid = Microgrid(
         actors=[
             ComputingSystem(power_meters=power_meters),
@@ -44,7 +45,6 @@ def main(result_csv: str):
         storage=battery,
         storage_policy=POLICY,
         controllers=[monitor, carbon_aware_controller],
-        zone="DE",
         step_size=60,  # global step size (can be overridden by actors or controllers)
     )
     environment.add_microgrid(microgrid)

--- a/examples/sil_example.py
+++ b/examples/sil_example.py
@@ -17,7 +17,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 
 from controller_example import SIM_START, DURATION, POLICY
-from examples._data import load_carbon_data, load_solar_data
+from examples._data import load_solar_data
 from vessim.actor import ComputingSystem, Generator
 from vessim.controller import Monitor
 from vessim.cosim import Environment, Microgrid
@@ -33,7 +33,6 @@ RASPI_ADDRESS = "http://192.168.207.71"
 
 def main(result_csv: str):
     environment = Environment(sim_start=SIM_START)
-    environment.add_grid_signal("carbon_intensity", HistoricalSignal(load_carbon_data()))
 
     power_meters = [
         HttpPowerMeter(name="gcp", address=GCP_ADDRESS),
@@ -60,7 +59,6 @@ def main(result_csv: str):
         storage=SimpleBattery(capacity=100),
         storage_policy=POLICY,
         controllers=[monitor, carbon_aware_controller],
-        zone="DE",
         step_size=60,  # global step size (can be overridden by actors or controllers)
     )
     environment.add_microgrid(microgrid)

--- a/vessim/controller.py
+++ b/vessim/controller.py
@@ -17,13 +17,8 @@ if TYPE_CHECKING:
 
 class Controller(ABC):
 
-    def __init__(
-        self,
-        step_size: Optional[int] = None,
-        grid_signals: Optional[dict[str, Signal]] = None,
-    ):
+    def __init__(self, step_size: Optional[int] = None):
         self.step_size = step_size
-        self.grid_signals = grid_signals
 
     @abstractmethod
     def start(self, microgrid: Microgrid, clock: Clock) -> None:
@@ -59,7 +54,8 @@ class Monitor(Controller):
         grid_signals: Optional[dict[str, Signal]] = None,
         monitor_storage: bool = True,
     ):
-        super().__init__(step_size=step_size, grid_signals=grid_signals)
+        super().__init__(step_size=step_size)
+        self.grid_signals = grid_signals
         self.monitor_storage = monitor_storage
         self.monitor_log: dict[datetime, dict] = defaultdict(dict)
         self.custom_monitor_fns: list[Callable] = []

--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -31,9 +31,7 @@ class Microgrid:
         self.zone = zone
         self.step_size = step_size
 
-    def initialize(
-        self, world: mosaik.World, clock: Clock, grid_signals: dict[str, Signal]
-    ):
+    def initialize(self, world: mosaik.World, clock: Clock):
         """Create co-simulation entities and connect them to world."""
         grid_sim = world.start("Grid")
         grid_entity = grid_sim.Grid(storage=self.storage, policy=self.storage_policy)
@@ -47,7 +45,7 @@ class Microgrid:
             actor_names_and_entities.append((actor.name, actor_entity))
 
         for controller in self.controllers:
-            controller.start(self, clock, grid_signals)
+            controller.start(self, clock)
             step_size = controller.step_size if controller.step_size else self.step_size
             controller_sim = world.start("Controller", step_size=step_size)
             controller_entity = controller_sim.Controller(controller=controller)
@@ -87,16 +85,10 @@ class Environment:
     def __init__(self, sim_start):
         self.clock = Clock(sim_start)
         self.microgrids = []
-        self.grid_signals = {}
         self.world = mosaik.World(self.COSIM_CONFIG) # type: ignore
 
     def add_microgrid(self, microgrid: Microgrid):
         self.microgrids.append(microgrid)
-
-    def add_grid_signal(self, name: str, grid_signal: Signal):
-        if len(self.microgrids) > 0:
-            raise RuntimeError("Add all grid signals before adding microgrids.")
-        self.grid_signals[name] = grid_signal
 
     def run(
         self,
@@ -106,7 +98,7 @@ class Environment:
     ):
         try:
             for microgrid in self.microgrids:
-                microgrid.initialize(self.world, self.clock, self.grid_signals)
+                microgrid.initialize(self.world, self.clock)
             if until is None:
                 until = int("inf")
             self.world.run(

--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -9,7 +9,6 @@ import mosaik_api  # type: ignore
 
 from vessim.actor import Actor
 from vessim.controller import Controller
-from vessim.signal import Signal
 from vessim.storage import Storage, StoragePolicy, DefaultStoragePolicy
 from vessim.util import Clock
 

--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -20,14 +20,12 @@ class Microgrid:
         controllers: Optional[list[Controller]] = None,
         storage: Optional[Storage] = None,
         storage_policy: Optional[StoragePolicy] = None,
-        zone: Optional[str] = None,
         step_size: int = 1,  # global default
     ):
         self.actors = actors if actors is not None else []
         self.controllers = controllers if controllers is not None else []
         self.storage = storage
         self.storage_policy = storage_policy
-        self.zone = zone
         self.step_size = step_size
 
     def initialize(self, world: mosaik.World, clock: Clock):

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -99,7 +99,6 @@ class SilController(Controller):
         api_port: int = 8000,
         request_collector_interval: float = 1,
         step_size: Optional[int] = None,
-        grid_signals: Optional[dict[str, Signal]] = None,
     ):
         super().__init__(step_size=step_size)
         self.api_routes = api_routes
@@ -117,7 +116,6 @@ class SilController(Controller):
 
         self.microgrid: Optional[Microgrid] = None
         self.clock: Optional[Clock] = None
-        self.grid_signals = grid_signals
 
     def start(self, microgrid: Microgrid, clock: Clock) -> None:
         self.microgrid = microgrid
@@ -131,7 +129,6 @@ class SilController(Controller):
                 api_routes=self.api_routes,
                 api_host=self.api_host,
                 api_port=self.api_port,
-                grid_signals=self.grid_signals,
             ),
         ).start()
         logger.info("Started SiL Controller API server process 'Vessim API'")

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -99,6 +99,7 @@ class SilController(Controller):
         api_port: int = 8000,
         request_collector_interval: float = 1,
         step_size: Optional[int] = None,
+        grid_signals: Optional[dict[str, Signal]] = None,
     ):
         super().__init__(step_size=step_size)
         self.api_routes = api_routes
@@ -116,12 +117,11 @@ class SilController(Controller):
 
         self.microgrid: Optional[Microgrid] = None
         self.clock: Optional[Clock] = None
-        self.grid_signals: Optional[dict] = None
+        self.grid_signals = grid_signals
 
-    def start(self, microgrid: Microgrid, clock: Clock, grid_signals: dict) -> None:
+    def start(self, microgrid: Microgrid, clock: Clock) -> None:
         self.microgrid = microgrid
         self.clock = clock
-        self.grid_signals = grid_signals
 
         multiprocessing.Process(
             target=_serve_api,


### PR DESCRIPTION
The grid signals from the environment were just passed around a couple of times throughout different classes, but only the controllers actually use them.
Now they are just initialized with them and there is no more unnecessary and complicated passing of these arguments, saving some complexity.