### PR TITLE
environment.add_microgrid() is now the only way to create new microgrids

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vessim allows you to simulate energy systems next to real or simulated computing
 ```python
 from vessim.actor import ComputingSystem, Generator
 from vessim.controller import Monitor
-from vessim.cosim import Environment, Microgrid
+from vessim.cosim import Environment
 from vessim.power_meter import MockPowerMeter
 from vessim.signal import HistoricalSignal
 from vessim.storage import SimpleBattery
@@ -22,7 +22,7 @@ from vessim.storage import SimpleBattery
 environment = Environment(sim_start="15-06-2022")
 
 monitor = Monitor()
-microgrid = Microgrid(
+environment.add_microgrid(
     actors=[
         ComputingSystem(power_meters=[MockPowerMeter(p=100)]),
         Generator(signal=HistoricalSignal.from_dataset("solcast2022_global")),
@@ -31,7 +31,6 @@ microgrid = Microgrid(
     storage=SimpleBattery(capacity=100),
     step_size=60,
 )
-environment.add_microgrid(microgrid)
 
 environment.run(until=24 * 3600)  # 24h
 monitor.to_csv("result.csv")

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -12,8 +12,9 @@ DURATION = 3600 * 24 * 2  # two days
 
 def main(result_csv: str):
     environment = Environment(sim_start=SIM_START)
+
     monitor = Monitor()  # stores simulation result on each step
-    microgrid = Microgrid(
+    environment.add_microgrid(
         actors=[
             ComputingSystem(power_meters=[
                 MockPowerMeter(p=2.194),
@@ -23,10 +24,8 @@ def main(result_csv: str):
         ],
         controllers=[monitor],
         storage=SimpleBattery(capacity=100),
-        zone="DE",
         step_size=60,  # global step size (can be overridden by actors or controllers)
     )
-    environment.add_microgrid(microgrid)
 
     environment.run(until=DURATION)
     monitor.to_csv(result_csv)

--- a/examples/sil_example.py
+++ b/examples/sil_example.py
@@ -51,7 +51,7 @@ def main(result_csv: str):
             ComputeNode(name="raspi", address=RASPI_ADDRESS),
         ],
     )
-    microgrid = Microgrid(
+    environment.add_microgrid(
         actors=[
             ComputingSystem(power_meters=power_meters),
             Generator(signal=HistoricalSignal(load_solar_data(sqm=0.4 * 0.5))),
@@ -61,7 +61,6 @@ def main(result_csv: str):
         controllers=[monitor, carbon_aware_controller],
         step_size=60,  # global step size (can be overridden by actors or controllers)
     )
-    environment.add_microgrid(microgrid)
 
     environment.run(until=DURATION, rt_factor=RT_FACTOR, print_progress=False)
     monitor.to_csv(result_csv)


### PR DESCRIPTION
Got rid of `microgrid.initialize()`