### PR TITLE
GridSim is now time-based

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -1,7 +1,7 @@
-from _data import load_carbon_data, load_solar_data
+from _data import load_solar_data
 from vessim.actor import ComputingSystem, Generator
 from vessim.controller import Monitor
-from vessim.cosim import Environment, Microgrid
+from vessim.cosim import Environment
 from vessim.power_meter import MockPowerMeter
 from vessim.signal import HistoricalSignal
 from vessim.storage import SimpleBattery

--- a/vessim/controller.py
+++ b/vessim/controller.py
@@ -8,8 +8,8 @@ from typing import Any, TYPE_CHECKING, MutableMapping, Optional, Callable
 import mosaik_api  # type: ignore
 import pandas as pd
 
-from vessim.util import Clock
 from vessim.signal import Signal
+from vessim.util import Clock
 
 if TYPE_CHECKING:
     from vessim.cosim import Microgrid

--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -30,16 +30,19 @@ class Microgrid:
         self.storage_policy = storage_policy
         self.step_size = step_size
 
-        grid_sim = world.start("Grid")
-        grid_entity = grid_sim.Grid(storage=storage, policy=storage_policy)
-
         actor_names_and_entities = []
         for actor in actors:
             actor_step_size = actor.step_size if actor.step_size else step_size
             actor_sim = world.start("Actor", clock=clock, step_size=actor_step_size)
+            # We initialize all actors before the grid simulation to make sure that
+            # there is already a valid p_delta at step 0
             actor_entity = actor_sim.Actor(actor=actor)
-            world.connect(actor_entity, grid_entity, "p")
             actor_names_and_entities.append((actor.name, actor_entity))
+
+        grid_sim = world.start("Grid", step_size=step_size)
+        grid_entity = grid_sim.Grid(storage=storage, policy=storage_policy)
+        for actor_name, actor_entity in actor_names_and_entities:
+            world.connect(actor_entity, grid_entity, "p")
 
         for controller in controllers:
             controller.start(self, clock)
@@ -126,7 +129,7 @@ class Environment:
 
 class GridSim(mosaik_api.Simulator):
     META = {
-        "type": "event-based",
+        "type": "time-based",
         "models": {
             "Grid": {
                 "public": True,
@@ -139,10 +142,15 @@ class GridSim(mosaik_api.Simulator):
     def __init__(self):
         super().__init__(self.META)
         self.eid = "Grid"
+        self.step_size = None
         self.storage = None
         self.policy = None
         self.p_delta = 0.0
         self._last_step_time = 0
+
+    def init(self, sid, time_resolution=1.0, **sim_params):
+        self.step_size = sim_params["step_size"]
+        return self.meta
 
     def create(self, num, model, **model_params):
         assert num == 1, "Only one instance per simulation is supported"
@@ -153,16 +161,13 @@ class GridSim(mosaik_api.Simulator):
         return [{"eid": self.eid, "type": model}]
 
     def step(self, time, inputs, max_advance):
-        duration = time - self._last_step_time
-        self._last_step_time = time
-        if duration == 0:
-            return
         p_delta = sum(inputs[self.eid]["p"].values())
         if self.storage is None:
             self.p_delta = p_delta
         else:
             assert self.policy is not None
-            self.p_delta = self.policy.apply(self.storage, p_delta, duration)
+            self.p_delta = self.policy.apply(self.storage, p_delta, self.step_size)
+        return time + self.step_size
 
     def get_data(self, outputs):
         return {self.eid: {"p_delta": self.p_delta}}


### PR DESCRIPTION
1. to ensure that there is a valid p_delta at step 0
2. to ensure that the storage is periodically (dis)charged
3. so that we can make use of max_advance within individual simulators as all models are time-based now

closes #178