### PR TITLE
Re-Added Log Suppression for `rt_strict` Warnings

### DIFF
--- a/vessim/_util.py
+++ b/vessim/_util.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from typing import Union
+from loguru import logger
+import sys
 
 import pandas as pd
 import numpy as np
@@ -18,3 +20,29 @@ class Clock:
 
     def to_simtime(self, dt: datetime) -> int:
         return int((dt - self.sim_start).total_seconds())
+
+
+def disable_rt_warnings(behind_threshold: float):
+    """Disables Mosaik's rt_check warnings.
+
+    The simulation is always behind by a few fractions of a second (which is
+    fine, code needs time to execute) which Mosaik logs as a Warning. These
+    Warnings are flagged as bugs in Mosaik's current developement and should be
+    fixed within its next release. Until then, this function should do.
+
+    Args:
+        behind_threshold: Time the simulation is allowed to be behind schedule.
+    """
+
+    def filter_record(record):
+        is_warning = record["level"].name == "WARNING"
+        is_mosaik_log = record["name"].startswith("mosaik")
+        is_below_threshold = (
+            record["function"] == "rt_check"
+            and float(record["message"].split(" - ")[1].split("s")[0]) < behind_threshold
+        )
+        return not (is_warning and is_mosaik_log and is_below_threshold)
+
+    # Add the filter to the logger
+    logger.remove()
+    logger.add(sys.stdout, filter=filter_record)

--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -9,7 +9,7 @@ import mosaik_api_v3  # type: ignore
 from vessim.actor import Actor
 from vessim.controller import Controller
 from vessim.storage import Storage, StoragePolicy, DefaultStoragePolicy
-from vessim._util import Clock
+from vessim._util import Clock, disable_rt_warnings
 
 
 class Microgrid:
@@ -118,17 +118,18 @@ class Environment:
         until: Optional[int] = None,
         rt_factor: Optional[float] = None,
         print_progress: bool | Literal["individual"] = True,
+        behind_threshold: float = 0.01
     ):
         if until is None:
             # there is no integer representing infinity in python
             until = float("inf") # type: ignore
+        if rt_factor:
+            disable_rt_warnings(behind_threshold)
         try:
             self.world.run(
                 until=until, rt_factor=rt_factor, print_progress=print_progress
             )
-        except Exception as e:
-            if str(e).startswith("Simulation too slow for real-time factor"):
-                return
+        except Exception:
             for microgrid in self.microgrids:
                 microgrid.finalize()
             raise


### PR DESCRIPTION
Our current "solution" for suppressing the "Simulation too slow for real-time factor..." warning does not work. Not only did I never add the `rt_strict=True` arg for SiL sims, meaning the exception that we want to ignore (instead of the warning to be logged) is never raised in the first place, but checking for the particular exception and returning actually ends the simulation. 

So for now, let's re-add the function that suppresses mosaik warnings and apply it for SiL sims.