### PR TITLE
Replaced Queue w/ Pipe in SiL Module + Time Series in Broker

### DIFF
--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -62,6 +62,7 @@ class Microgrid:
         """Returns a Dict with the current state of the microgrid for monitoring."""
         state = copy(self.__dict__)
         state["controllers"] = []  # controllers are not needed and often not pickleable
+        state["actor"] = []  # actor info can be supplied through Actor.state()
         return state
 
     def finalize(self):

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -189,7 +189,7 @@ class SilController(Controller):
                     microgrid=self.microgrid,
                 )
             # Calculate elapsed time and sleep if necessary
-            elapsed_time = time.time() - start_time
+            elapsed_time = time.monotonic() - start_time
             time_to_wait = self.request_collector_interval - elapsed_time
             if time_to_wait > 0:
                 time.sleep(time_to_wait)

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -6,7 +6,7 @@ This module is still experimental, the public API might change at any time.
 from __future__ import annotations
 
 from multiprocessing import Process, Pipe
-from multiprocessing.connection import Connection
+from multiprocessing.connection import PipeConnection
 from collections import defaultdict
 from datetime import datetime, timedelta
 from threading import Thread
@@ -26,7 +26,7 @@ from vessim._util import DatetimeLike
 
 
 class Broker:
-    def __init__(self, data_pipe_out: Connection, events_pipe_in: Connection):
+    def __init__(self, data_pipe_out: PipeConnection, events_pipe_in: PipeConnection):
         self._data_pipe_out = data_pipe_out
         self._events_pipe_in = events_pipe_in
         self._microgrid_ts: dict[DatetimeLike, Microgrid] = {}

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -98,7 +98,7 @@ class Broker:
     def get_actor_infos(self, actor: str) -> dict:
         return self._actor_infos[actor]
 
-    def get_actor_infos_ts(
+    def get_actors_infos_ts(
         self, start_time: Optional[DatetimeLike] = None, end_time: Optional[DatetimeLike] = None
     ) -> list[tuple[DatetimeLike, dict[str, dict]]]:
         with self._ts_lock:

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -10,8 +10,9 @@ from multiprocessing.connection import Connection
 from collections import defaultdict
 from datetime import datetime, timedelta
 from threading import Thread, Lock
-from typing import Any, Optional, Callable
+from typing import Any, Optional, Callable, List, Tuple, Dict
 from bisect import bisect_left, bisect_right
+import numpy as np
 import time
 
 import pandas as pd
@@ -30,12 +31,12 @@ class Broker:
     def __init__(self, data_pipe_out: Connection, events_pipe_in: Connection):
         self._data_pipe_out = data_pipe_out
         self._events_pipe_in = events_pipe_in
-        self._microgrid_ts: list[tuple[DatetimeLike, Microgrid]] = []
-        self._actor_infos_ts: list[tuple[DatetimeLike, dict]] = []
-        self._p_delta_ts: list[tuple[DatetimeLike, float]] = []
-        self._e_delta_ts: list[tuple[DatetimeLike, float]] = []
+        self._microgrid_ts: List[Tuple[DatetimeLike, Microgrid]] = []
+        self._actor_infos_ts: List[Tuple[DatetimeLike, Dict]] = []
+        self._p_delta_ts: List[Tuple[DatetimeLike, float]] = []
+        self._e_delta_ts: List[Tuple[DatetimeLike, float]] = []
         self._microgrid: Optional[Microgrid] = None
-        self._actor_infos: dict[str, dict] = {}
+        self._actor_infos: Dict[str, Dict] = {}
         self._p_delta: float = 0
         self._e_delta: float = 0
         self._ts_lock: Lock = Lock()
@@ -49,7 +50,8 @@ class Broker:
             self._p_delta = data["p_delta"]
             self._e_delta = data["e_delta"]
             with self._ts_lock:
-                assert isinstance(time, DatetimeLike)
+                assert isinstance(time, (str, datetime, np.datetime64))
+                assert self._microgrid is not None
                 self._microgrid_ts.append((time, self._microgrid))
                 self._actor_infos_ts.append((time, self._actor_infos))
                 self._p_delta_ts.append((time, self._p_delta))
@@ -93,12 +95,12 @@ class Broker:
             ts = self._microgrid_ts.copy()
         return self._get_ts_range(ts, start_time, end_time)
 
-    def get_actor(self, actor: str) -> dict:
+    def get_actor_infos(self, actor: str) -> dict:
         return self._actor_infos[actor]
 
-    def get_actor_ts(
+    def get_actor_infos_ts(
         self, start_time: Optional[DatetimeLike] = None, end_time: Optional[DatetimeLike] = None
-    ) -> list[tuple[DatetimeLike, dict]]:
+    ) -> list[tuple[DatetimeLike, dict[str, dict]]]:
         with self._ts_lock:
             ts = self._actor_infos_ts.copy()
         return self._get_ts_range(ts, start_time, end_time)

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -178,7 +178,7 @@ class SilController(Controller):
 
     def _collect_set_requests_loop(self):
         while True:
-            start_time = time.time()
+            start_time = time.monotonic()
             events_by_category = defaultdict(dict)
             while self.events_pipe_out.poll():
                 event = self.events_pipe_out.recv()

--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -135,9 +135,9 @@ class SilController(Controller):
             while self.events_pipe_out.poll():
                 event = self.events_pipe_out.recv()
                 events_by_category[event["category"]][event["time"]] = event["value"]
-            for category, _ in events_by_category.items():
+            for category, events in events_by_category.items():
                 self.request_collectors[category](
-                    events=events_by_category[category],
+                    events=events,
                     microgrid=self.microgrid,
                 )
             sleep(self.request_collector_interval)


### PR DESCRIPTION
- Replaced Queue w/ Pipe
- Broker now has a thread running that listens for incoming objects via recv(). Objects are removed after reading which solved the problem of the queue overflowing if the the api is not used frequently. 
- Broker now saves incoming data as time series and offers new getters for this
- Removed actor from the pickeled representation of Microgrid. Users can decide for themselves what values they want to be able to access via Actor.state() which is sent to the broker instead. This should solve the problem of the size of the pickled Microgrid being to large.

@Impelon Is this what you had in mind for your use case?