### PR TITLE
Start `Broker`'s receiver in API process

### DIFF
--- a/vessim/sil.py
+++ b/vessim/sil.py
@@ -40,7 +40,6 @@ class Broker:
         self._p_delta: float = 0
         self._e_delta: float = 0
         self._ts_lock: Lock = Lock()
-        Thread(target=self._recv_data, daemon=True).start()
 
     def _recv_data(self) -> None:
         while True:
@@ -204,6 +203,7 @@ def _serve_api(
     broker: Broker,
     grid_signals: dict[str, Signal],
 ):
+    Thread(target=broker._recv_data, daemon=True).start()
     app = FastAPI()
     api_routes(app, broker, grid_signals)
     config = uvicorn.Config(app=app, host=api_host, port=api_port, access_log=False)


### PR DESCRIPTION
The receive-Thread must be started by the same `multiprocessing.Process` as the process the API is running in. Otherwise any data from the broker will be unavailable to the API.

Starting the recieve-Thread of the broker directly on instantiation is an oversight, as it needs to be started later manually by the API process.

One could also add a `start` function to the Broker if one wanted to make it prettier, but this is the minimum needed to actually make the new SIL interface work.