### PR TITLE
Workflow update to avoid cache misses

### DIFF
--- a/.github/workflows/building-and-installation.yml
+++ b/.github/workflows/building-and-installation.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .venv
-        key: venv-${{ steps.setup-python.outputs.python-version }}
+        key: venv-${{ matrix.python-version }}
 
     # build package
     - name: Build package out of local poject

--- a/.github/workflows/linting-and-testing.yml
+++ b/.github/workflows/linting-and-testing.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .venv
-        key: venv-${{ steps.setup-python.outputs.python-version }}
+        key: venv-${{ matrix.python-version }}
 
     # install dependencies if cache not available
     - name: Install dependencies


### PR DESCRIPTION
This should hopefully reduce cache misses in the pipeline because the venv name is no longer dependent on the python subversion (key is now `venv-3.12` instead of something like `venv-3.12.3`, which often changes)