### PR TITLE
Date Parsing Fggix

### DIFF
--- a/vessim/_util.py
+++ b/vessim/_util.py
@@ -13,7 +13,7 @@ DatetimeLike = Union[str, datetime, np.datetime64]
 
 class Clock:
     def __init__(self, sim_start: str | datetime):
-        self.sim_start = pd.to_datetime(sim_start)
+        self.sim_start = pd.to_datetime(sim_start, dayfirst=True)
 
     def to_datetime(self, simtime: int) -> datetime:
         return self.sim_start + timedelta(seconds=simtime)


### PR DESCRIPTION
```
environment = vs.Environment(sim_start="15-06-2022")
```
results in:
```
UserWarning: Parsing dates in %d-%m-%Y format when dayfirst=False (the default) was specified. Pass `dayfirst=True` or specify a format to silence this warning.
  self.sim_start = pd.to_datetime(sim_start)
```
upon scenario execution. Passing `dayFirst=True` now to fix.