### PR TITLE
Fix #234

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -26,9 +26,7 @@ class TestHistoricalSignal:
     @pytest.fixture
     def hist_signal_forecast(self) -> vs.HistoricalSignal:
         index = pd.date_range("2023-01-01T00:00:00", "2023-01-01T01:00:00", freq="20T")
-        actual = pd.DataFrame(
-            {"a": [1, 5, 3, 2], "b": [0, 1, 2, 3], "c": [4, 3, 2, 7]}, index=index
-        )
+        actual = pd.DataFrame({"a": [1, 5, 3, 2], "b": [0, 1, 2, 3]}, index=index)
 
         forecast_data = [
             ["2023-01-01T00:00:00", "2023-01-01T00:10:00", 2, 2.5],
@@ -294,11 +292,9 @@ class TestHistoricalSignal:
         # Complicated because np.nan == np.nan is False
         assert forecast.keys() == expected.keys()
         assert all(
-            np.isnan(expected[k]) if np.isnan(forecast[k])
-            else forecast[k] == expected[k]
+            np.isnan(expected[k]) if np.isnan(forecast[k]) else forecast[k] == expected[k]
             for k in forecast.keys()
         )
-
 
     def test_forecast_fails_if_column_not_specified(self, hist_signal):
         with pytest.raises(ValueError):

--- a/vessim/signal.py
+++ b/vessim/signal.py
@@ -364,6 +364,10 @@ class HistoricalSignal(Signal):
             # Actual value is used for interpolation
             times = np.insert(times, 0, start_time)
             # https://github.com/dos-group/vessim/issues/234
+            # Use the length of the actual data to determine the column:
+            # self._actual is a dict[str, tuple[np.ndarray, np.ndarray]]
+            # -> every key is a column name
+            # -> if len(self._actual) == 1, _actual is based on pd.Series and column is None
             data = np.insert(
                 data, 0, self.now(start_time, None if len(self._actual) == 1 else column)
             )

--- a/vessim/signal.py
+++ b/vessim/signal.py
@@ -364,7 +364,9 @@ class HistoricalSignal(Signal):
             # Actual value is used for interpolation
             times = np.insert(times, 0, start_time)
             # https://github.com/dos-group/vessim/issues/234
-            data = np.insert(data, 0, self.now(start_time, None if data.ndim == 1 else column))
+            data = np.insert(
+                data, 0, self.now(start_time, None if len(self._actual) == 1 else column)
+            )
             if resample_method == "ffill":
                 new_data = data[np.searchsorted(times, new_times, side="right") - 1]
             elif resample_method == "nearest":


### PR DESCRIPTION
- For Dataframes, we're now checking for equal column names and raise an error in case
- For Series,  their name is no longer used as column name in `_resample_to_frequency()`. Series are identified by checking the length of `self._actual` (=1)

closes #234 

Thank you @Impelon for the detailed bug report. If you have further thoughts about this, please let us know!