### PR TITLE
Finalize Actos when Microgrid Finalizes

### DIFF
--- a/vessim/actor.py
+++ b/vessim/actor.py
@@ -49,6 +49,9 @@ class Actor(ActorBase):
             "p": self.p(now),
         }
 
+    def finalize(self) -> None:
+        self.signal.finalize()
+
 
 class ComputingSystem(ActorBase):
     """Model of the computing system.

--- a/vessim/actor.py
+++ b/vessim/actor.py
@@ -92,6 +92,10 @@ class ComputingSystem(ActorBase):
             "nodes": {signal.name: -signal.now(at=now) for signal in self.nodes},
         }
 
+    def finalize(self) -> None:
+        for node in self.nodes:
+            node.finalize()
+
 
 class _ActorSim(mosaik_api_v3.Simulator):
     META = {

--- a/vessim/cosim.py
+++ b/vessim/cosim.py
@@ -102,6 +102,8 @@ class Microgrid:
         """
         for controller in self.controllers:
             controller.finalize()
+        for actor in self.actors:
+            actor.finalize()
 
 
 class Environment:


### PR DESCRIPTION
In `Microgrid.finalize()` we already call `finalize()` for all controllers but not for actors. This means that `ActorBase.finalize()` is never called.

Use Case: When using an actor with a `CollectorSignal` child, I want its thread to terminate with the simulation. Currently, the thread keeps on running until the program ends.