### PR TITLE
Add battery degradation and optional integration with BLAST-Lite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,12 @@ requests = {version = "^2.26.0", optional = true}
 fastapi = {version = "^0.104.0", optional = true}
 uvicorn = {version = "^0.23.0", optional = true}
 
+# Optional dependencies (battery degradation)
+blast-lite = {version = "^1.0.5", optional = true, python = ">=3.9"}
+
 [tool.poetry.extras]
 sil = ["requests", "fastapi", "uvicorn"]
+model-deg = ["blast-lite"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/vessim/__init__.py
+++ b/vessim/__init__.py
@@ -5,7 +5,7 @@ from vessim.controller import Controller, Monitor
 from vessim.cosim import Microgrid, Environment
 from vessim.policy import MicrogridPolicy, DefaultMicrogridPolicy
 from vessim.signal import Signal, HistoricalSignal, MockSignal, CollectorSignal
-from vessim.storage import Storage, SimpleBattery, ClcBattery
+from vessim.storage import Storage, Battery, BatteryDegradation, SimpleBattery, ClcBattery
 
 __all__ = [
     "ActorBase",
@@ -22,9 +22,18 @@ __all__ = [
     "Signal",
     "HistoricalSignal",
     "Storage",
+    "Battery",
+    "BatteryDegradation",
     "ClcBattery",
     "SimpleBattery",
 ]
+
+try:
+    from vessim.storage import ModelDegradation  # noqa: F401
+
+    __all__.extend(["ModelDegradation"])
+except ImportError:
+    pass
 
 try:
     from vessim.sil import Broker, SilController, WatttimeSignal, get_latest_event  # noqa: F401


### PR DESCRIPTION
This PR adds new abstract base classes to allow for simulating battery degradation and [BLAST-Lite](https://github.com/NREL/BLAST-Lite) as an optional dependency to provide battery degradation models.

### TODO

- [ ] Add tests
- [ ] Add documentation