### PR TITLE
Organize development dependencies for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,6 @@ sil = [
     "fastapi>=0.104.0",
     "uvicorn>=0.23.0",
 ]
-dev = [
-    "pytest",
-    "mypy",
-    "types-psutil",
-    "pandas-stubs",
-    "types-requests",
-    "black",
-    "ruff",
-]
 docs = [
     "setuptools",
     "sphinx",
@@ -65,6 +56,19 @@ docs = [
     "windpowerlib",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest",
+    "mypy",
+    "types-psutil",
+    "pandas-stubs",
+    "types-requests",
+    "black",
+    "ruff",
+]
+
+[[tool.uv.sources]]
+url = "https://pypi.org/simple"
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- move `dev` requirements from extras to `dependency-groups`
- add default uv source list
- tidy spacing so `[build-system]` follows `tool.uv.sources` immediately

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685af845a464832b86f243a40b5ae7d5